### PR TITLE
Polaris variables schema, and baseline validation #8260

### DIFF
--- a/docs/partials/readme.usage.after.md
+++ b/docs/partials/readme.usage.after.md
@@ -10,15 +10,16 @@ When importing a playbook from the Polaris collection you need to pass along as 
       admins_active: # create users
         - username: alice
           fullname: Alice
+          pubkey: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBZl3lQTRGhD5mdGgFEVuX+CAnTMz9MuY+f4vE2cqk9G alice@host
       admins_removed: # remove users
         - bob
          
       docker_users: # Sudo-less docker usage
         - alice
          
--     #docker_registry_login_registry: https://index.docker.io/v1/
-      #docker_registry_login_username: alice
-      #docker_registry_login_password: secret
+-     #docker_registry: https://ghcr.io/
+      #docker_registry_login: alice
+      #docker_registry_pat: secret
 
       #tailscale_authkey: secret
       #tailscale_args:

--- a/docs/partials/readme.usage.after.md
+++ b/docs/partials/readme.usage.after.md
@@ -1,0 +1,27 @@
+### Variables
+
+When importing a playbook from the Polaris collection you need to pass along as a variable the
+`polaris` dictionary, which can have the following value properties set:
+
+```yaml
+- ansible.builtin.import_playbook: linkorb.polaris.layers
+  vars:
+    polaris:
+      admins_active: # create users
+        - username: alice
+          fullname: Alice
+      admins_removed: # remove users
+        - bob
+         
+      docker_users: # Sudo-less docker usage
+        - alice
+         
+-     #docker_registry_login_registry: https://index.docker.io/v1/
+      #docker_registry_login_username: alice
+      #docker_registry_login_password: secret
+
+      #tailscale_authkey: secret
+      #tailscale_args:
+```
+
+Refer to [the schema](./variables.schema.yaml) for further details.

--- a/playbooks/baseline/admins.yml
+++ b/playbooks/baseline/admins.yml
@@ -6,5 +6,5 @@
     - polaris.layer.baseline.admins
   roles:
     - role: cchurch.admin-users
-      admin_users: "{{ polaris_admins_active }}"
-      admin_users_to_remove: "{{ polaris_admins_removed }}"
+      admin_users: "{{ polaris.admins_active }}"
+      admin_users_to_remove: "{{ polaris.admins_removed }}"

--- a/playbooks/baseline/validate.yml
+++ b/playbooks/baseline/validate.yml
@@ -3,7 +3,7 @@
   become: true
   tags:
     - polaris.layer.baseline
-    - polaris.layer.baseline.config
+    - polaris.layer.baseline.validate
   tasks:
   - name: load polaris variables validation schema
     ansible.builtin.set_fact:

--- a/playbooks/baseline/validate.yml
+++ b/playbooks/baseline/validate.yml
@@ -1,0 +1,21 @@
+- name: Baseline - validate
+  hosts: polaris_hosts
+  become: true
+  tags:
+    - polaris.layer.baseline
+    - polaris.layer.baseline.config
+  tasks:
+  - name: load polaris variables validation schema
+    ansible.builtin.set_fact:
+      criteria: "{{ lookup('ansible.builtin.file', playbook_dir ~ '/../../variables.schema.yaml') | from_yaml }}"
+
+  - name: validate polaris variables
+    ansible.builtin.set_fact:
+      config_validity: "{{ vars.polaris|ansible.utils.validate(criteria, engine='ansible.utils.jsonschema', draft='draft7') }}"
+
+  - when: config_validity[0].message is defined
+    name: fail on polaris variables validation error
+    ansible.builtin.fail:
+      msg: >
+        polaris.{{ config_validity[0].data_path }}: {{ config_validity[0].message }}.
+        Please refer to the Polaris variables schema.

--- a/playbooks/container/docker_engine.yml
+++ b/playbooks/container/docker_engine.yml
@@ -19,7 +19,7 @@
         append: true
         groups: docker
       become: true
-      with_items: '{{ polaris_docker_users }}'
+      with_items: '{{ polaris.docker_users }}'
     - name: Install and enable juicedata/juicefs volume plugin
       community.docker.docker_plugin:
         plugin_name: juicedata/juicefs
@@ -35,9 +35,9 @@
   tasks:
     - name: Login to the Docker Container Registry
       community.general.docker_login:
-        registry: "{{ polaris.docker_registry_login_registry }}"
-        username: "{{ polaris.docker_registry_login_username }}"
-        password: "{{ polaris.docker_registry_login_pat }}"
+        registry: "{{ polaris.docker_registry|default('https://ghcr.io/') }}"
+        username: "{{ polaris.docker_registry_username }}"
+        password: "{{ polaris.docker_registry_pat }}"
       become: true
         # reauthorize: true
 

--- a/playbooks/container/docker_engine.yml
+++ b/playbooks/container/docker_engine.yml
@@ -35,9 +35,9 @@
   tasks:
     - name: Login to the Docker Container Registry
       community.general.docker_login:
-        registry: "{{ polaris_docker_registry_login_registry }}"
-        username: "{{ polaris_docker_registry_login_username }}"
-        password: "{{ polaris_docker_registry_login_pat }}"
+        registry: "{{ polaris.docker_registry_login_registry }}"
+        username: "{{ polaris.docker_registry_login_username }}"
+        password: "{{ polaris.docker_registry_login_pat }}"
       become: true
         # reauthorize: true
 

--- a/playbooks/layers.yml
+++ b/playbooks/layers.yml
@@ -1,4 +1,6 @@
 # Common layer
+- name: Polaris variables validation
+  ansible.builtin.import_playbook: linkorb.polaris.baseline.validate
 - name: Hosts have standard configuration
   ansible.builtin.import_playbook: linkorb.polaris.baseline.config
 - name: Hosts have useful packages

--- a/playbooks/overlay/tailscale_client.yml
+++ b/playbooks/overlay/tailscale_client.yml
@@ -8,7 +8,7 @@
       include_role:
         name: artis3n.tailscale
       vars:
-        tailscale_args: "{{ polaris_tailscale_args }}"
-        tailscale_authkey: "{{ polaris_tailscale_authkey }}"
+        tailscale_args: "{{ polaris.tailscale_args }}"
+        tailscale_authkey: "{{ polaris.tailscale_authkey }}"
 
 

--- a/playbooks/provision.yml
+++ b/playbooks/provision.yml
@@ -7,7 +7,7 @@
     - polaris.
   roles:
     - role: cchurch.admin-users
-      admin_users: "{{ polaris_admins_active }}"
+      admin_users: "{{ polaris.admins_active }}"
 
 - name: python
   hosts: polaris_hosts # use -l to limit your hosts

--- a/variables.schema.yaml
+++ b/variables.schema.yaml
@@ -16,6 +16,12 @@ properties:
           type: string
         fullname:
           type: string
+        pubkey:
+          type: string
+          description: >
+            The public key to associate with the given user. This value can be a string containing the content of
+            the user's public key, a string containing a URL to a list of keys (e.g https://github.com/username.keys),
+            or a list of multiple strings containing either public key content or URLs
 
   admins_removed:
     type: array
@@ -32,15 +38,15 @@ properties:
     items:
       type: string
 
-  docker_registry_login_username:
+  docker_registry_username:
     type: string
 
-  docker_registry_login_password:
+  docker_registry_pat:
     type: string
 
-  docker_registry_login_registry:
+  docker_registry:
     type: string
-    default: https://index.docker.io/v1/
+    default: https://ghcr.io/
 
 
   tailscale_authkey:

--- a/variables.schema.yaml
+++ b/variables.schema.yaml
@@ -1,0 +1,54 @@
+type: object
+description: JSONSchema for collection variables
+additionalProperties: false
+
+properties:
+  admins_active:
+    type: array
+    description: List of admin users to create or update
+    default: []
+    items:
+      type: object
+      additionalProperties: false
+      required: ['username','fullname']
+      properties:
+        username:
+          type: string
+        fullname:
+          type: string
+
+  admins_removed:
+    type: array
+    description: List of usernames to remove
+    default: []
+    items:
+      type: string
+
+
+  docker_users:
+    type: array
+    description: List of sudo-less docker users
+    default: []
+    items:
+      type: string
+
+  docker_registry_login_username:
+    type: string
+
+  docker_registry_login_password:
+    type: string
+
+  docker_registry_login_registry:
+    type: string
+    default: https://index.docker.io/v1/
+
+
+  tailscale_authkey:
+    type: string
+    description: A Tailscale Node Authorization auth key.
+
+  tailscale_args:
+    type: string
+    description: >
+      Pass any additional command-line arguments to tailscale up.
+      Only tailscale up arguments can be passed in.


### PR DESCRIPTION
## Proposed changes

Initial support for Polaris variables validation via JSONSchema.

It was necessary to nest existing variables under a namespace in order to pass them to the validation function. I could not pass the top-level `vars`, as some data in in threw an error when Ansible tried to serialize the entire thing to JSON for validation.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] feat: non-breaking change which adds new functionality
- [ ] fix: non-breaking change which fixes a bug or an issue
- [ ] chore(deps): changes to dependencies
- [ ] test: adds or modifies a test
- [x] docs: creates or updates documentation
- [ ] style: changes that do not affect the meaning or function of code (e.g. formatting, whitespace, missing semi-colons etc.)
- [ ] perf: code change that improves performance
- [ ] revert: reverts a commit
- [ ] refactor: code change that neither fix a bug nor add a new feature
- [ ] ci: changes to continuous integration or continuous delivery scripts or configuration files
- [ ] chore: general tasks or anything that doesn't fit the other commit types

Please indicate if your PR introduces a breaking change
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [Contributing](https://github.com/linkorb/.github/blob/master/CONTRIBUTING.md) doc
- [x] I have read the [Creating and reviewing pull requests at LinkORB guide](https://engineering.linkorb.com/topics/git/articles/reviewing-pr/) doc
- [ ] Lint and unit tests pass locally with my changes
- [x] I have added/updated necessary documentation in the README.md or doc/ directories (if appropriate)
