### PR TITLE
feat: Reusable logging, audit and log shipping roles

### DIFF
--- a/playbooks/bastion.yml
+++ b/playbooks/bastion.yml
@@ -1,3 +1,21 @@
+- name: Bastion hosts are configured with Polaris tasks
+  ansible.builtin.import_playbook: linkorb.polaris.baseline.config
+
+- name: Bastion hosts have useful packages
+  ansible.builtin.import_playbook: linkorb.polaris.baseline.packages
+
+- name: Bastion hosts are configured with admin users
+  ansible.builtin.import_playbook: linkorb.polaris.baseline.admins
+
+- name: Bastion hosts are hardened
+  ansible.builtin.import_playbook: linkorb.polaris.baseline.hardening
+
+- name: Bastion hosts export metrics to Prometheus
+  ansible.builtin.import_playbook: linkorb.polaris.baseline.prometheus_node_exporter
+
+- name: Bastion hosts join the tailnet
+  ansible.builtin.import_playbook: linkorb.polaris.overlay.tailscale_client
+
 - name: Secure Bastion
   hosts: "{{ target_group | default('bastion') }}"
   become: yes

--- a/playbooks/bastion.yml
+++ b/playbooks/bastion.yml
@@ -1,0 +1,41 @@
+- name: Secure Bastion
+  hosts: "{{ target_group | default('bastion') }}"
+  become: yes
+  roles:
+    - role: linkorb.polaris.audit_session
+      audit_session_users: "{{ polaris_admins_active }}"
+    - role: linkorb.polaris.promtail_host
+      promtail_loki_url: https://draco-loki.linkorb.com/loki/api/v1/push
+      promtail_loki_basic_auth: "{{ promtail_loki_push_api_user }}"
+      promtail_constellation_label: bastion
+  tasks:
+    - name: Ensure admins are not in sudo group
+      command:
+        cmd: gpasswd -d {{ item.username }} sudo
+      register: remove_sudo
+      failed_when: remove_sudo.rc != 0 and 'is not a member of' not in remove_sudo.stderr
+      changed_when: "'is not a member of' not in remove_sudo.stderr"
+      loop: "{{ polaris_admins_active }}"
+
+    - name: Enable verbose sshd logging for jump/forward visibility
+      lineinfile:
+        path: /etc/ssh/sshd_config
+        regexp: '^#?LogLevel'
+        line: 'LogLevel VERBOSE'
+        state: present
+        create: no
+      notify: Restart ssh
+
+    - name: Flush handlers
+      meta: flush_handlers
+
+    - name: Revoke root SSH keys (Lock down server)
+      file:
+        path: /root/.ssh/authorized_keys
+        state: absent
+
+  handlers:
+    - name: Restart ssh
+      service:
+        name: ssh
+        state: restarted

--- a/playbooks/logging/audit_session.yml
+++ b/playbooks/logging/audit_session.yml
@@ -1,0 +1,6 @@
+- name: Polaris - audit session
+  hosts: '{{ target_group | default("polaris_hosts") }}'
+  become: yes
+  roles:
+    - role: linkorb.polaris.audit_session
+      audit_session_users: '{{ audit_session_users | default(polaris_admins_active | default([])) }}'

--- a/playbooks/logging/promtail.yml
+++ b/playbooks/logging/promtail.yml
@@ -1,0 +1,5 @@
+- name: Polaris - promtail log shipping
+  hosts: '{{ target_group | default("polaris_hosts") }}'
+  become: yes
+  roles:
+    - role: linkorb.polaris.promtail_host

--- a/playbooks/logging/promtail.yml
+++ b/playbooks/logging/promtail.yml
@@ -3,3 +3,4 @@
   become: yes
   roles:
     - role: linkorb.polaris.promtail_host
+      promtail_loki_url: '{{ promtail_loki_url }}'

--- a/roles/audit_session/README.md
+++ b/roles/audit_session/README.md
@@ -1,0 +1,15 @@
+# audit_session role
+
+Records interactive sessions with `tlog` and enables `auditd` with group-readable logs.
+
+## Variables
+- `audit_session_users` (list): users to switch shell to `tlog-rec-session` and place in `tlog/systemd-journal/audit` groups.
+- `audit_session_shell_path` (string): default `/usr/bin/tlog-rec-session`.
+- `audit_session_shell_binary` (string): default `/bin/bash`.
+- `audit_session_tlog_notice` (string): banner shown when recording starts.
+- `audit_session_writer` (string): `journal` (default) or `file`.
+- `audit_session_set_audit_log_group` (bool): set `log_group = audit` in auditd.conf.
+- `audit_session_extra_packages` (list): extra packages to install.
+
+## Handlers
+- `Restart auditd`

--- a/roles/audit_session/defaults/main.yml
+++ b/roles/audit_session/defaults/main.yml
@@ -1,0 +1,13 @@
+---
+audit_session_users: []  # list of {username: name}
+audit_session_shell_path: /usr/bin/tlog-rec-session
+audit_session_tlog_notice: |
+  \nATTENTION! Your session is being recorded!\n\n
+audit_session_writer: journal  # journal or file
+audit_session_shell_binary: /bin/bash
+
+# Whether to ensure auditd log_group is set to audit
+audit_session_set_audit_log_group: true
+
+# Extra packages to install alongside tlog/auditd if needed
+audit_session_extra_packages: []

--- a/roles/audit_session/handlers/main.yml
+++ b/roles/audit_session/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Restart auditd
+  service:
+    name: auditd
+    state: restarted

--- a/roles/audit_session/meta/main.yml
+++ b/roles/audit_session/meta/main.yml
@@ -1,0 +1,2 @@
+---
+dependencies: []

--- a/roles/audit_session/tasks/main.yml
+++ b/roles/audit_session/tasks/main.yml
@@ -1,0 +1,64 @@
+---
+- name: Install audit/tlog packages
+  apt:
+    name: "{{ ['tlog', 'auditd'] + audit_session_extra_packages }}"
+    state: present
+    update_cache: yes
+  when: ansible_os_family == 'Debian'
+
+- name: Create tlog group
+  group:
+    name: tlog
+    state: present
+
+- name: Create audit group
+  group:
+    name: audit
+    state: present
+
+- name: Configure auditd to allow group read access
+  lineinfile:
+    path: /etc/audit/auditd.conf
+    regexp: '^log_group ='
+    line: 'log_group = audit'
+    state: present
+  when: audit_session_set_audit_log_group
+  notify: Restart auditd
+
+- name: Create tlog lock directory
+  file:
+    path: /var/run/tlog
+    state: directory
+    owner: root
+    group: tlog
+    mode: '0775'
+
+- name: Deploy tlog-rec-session configuration
+  template:
+    src: tlog-rec-session.conf.j2
+    dest: /etc/tlog/tlog-rec-session.conf
+    mode: '0644'
+
+- name: Configure users to use tlog shell
+  user:
+    name: "{{ item.username }}"
+    shell: "{{ audit_session_shell_path }}"
+  loop: "{{ audit_session_users }}"
+  when: audit_session_users | length > 0 and item.username != 'root'
+
+- name: Add users to tlog/systemd-journal/audit groups
+  user:
+    name: "{{ item.username }}"
+    groups:
+      - tlog
+      - systemd-journal
+      - audit
+    append: yes
+  loop: "{{ audit_session_users }}"
+  when: audit_session_users | length > 0
+
+- name: Ensure auditd is running and enabled
+  service:
+    name: auditd
+    state: started
+    enabled: yes

--- a/roles/audit_session/templates/tlog-rec-session.conf.j2
+++ b/roles/audit_session/templates/tlog-rec-session.conf.j2
@@ -1,0 +1,5 @@
+{
+    "shell": "{{ audit_session_shell_binary }}",
+    "notice": "{{ audit_session_tlog_notice | trim }}\n",
+    "writer": "{{ audit_session_writer }}"
+}

--- a/roles/promtail_host/README.md
+++ b/roles/promtail_host/README.md
@@ -3,10 +3,12 @@
 Installs and configures Promtail to ship host logs to Loki.
 
 ## Variables
-- `promtail_loki_url` (string): Loki push endpoint.
+- `promtail_loki_url` (string, required): Loki push endpoint (pass in from inventory/vars).
 - `promtail_loki_basic_auth` (dict): `{name, password}` for basic auth.
 - `promtail_constellation_label` (string): optional label.
 - `promtail_extra_labels` (dict): extra labels applied to all logs.
+
+You must supply `promtail_loki_url` (e.g., via inventory or extra vars); it is not set by default in this public collection.
 
 ## Handlers
 - `Restart promtail`

--- a/roles/promtail_host/README.md
+++ b/roles/promtail_host/README.md
@@ -7,8 +7,6 @@ Installs and configures Promtail to ship host logs to Loki.
 - `promtail_loki_basic_auth` (dict): `{name, password}` for basic auth.
 - `promtail_constellation_label` (string): optional label.
 - `promtail_extra_labels` (dict): extra labels applied to all logs.
-- `promtail_scrape_jobs` (list): scrape job definitions; defaults cover journal, syslog, auditd.
-- `promtail_http_listen_port`, `promtail_grpc_listen_port`, `promtail_positions_file`.
 
 ## Handlers
 - `Restart promtail`

--- a/roles/promtail_host/README.md
+++ b/roles/promtail_host/README.md
@@ -1,0 +1,14 @@
+# promtail_host role
+
+Installs and configures Promtail to ship host logs to Loki.
+
+## Variables
+- `promtail_loki_url` (string): Loki push endpoint.
+- `promtail_loki_basic_auth` (dict): `{name, password}` for basic auth.
+- `promtail_constellation_label` (string): optional label.
+- `promtail_extra_labels` (dict): extra labels applied to all logs.
+- `promtail_scrape_jobs` (list): scrape job definitions; defaults cover journal, syslog, auditd.
+- `promtail_http_listen_port`, `promtail_grpc_listen_port`, `promtail_positions_file`.
+
+## Handlers
+- `Restart promtail`

--- a/roles/promtail_host/defaults/main.yml
+++ b/roles/promtail_host/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-promtail_loki_url: https://draco-loki.linkorb.com/loki/api/v1/push
+promtail_loki_url: ''
 promtail_loki_basic_auth: {}
 promtail_constellation_label: ''
 promtail_extra_labels: {}

--- a/roles/promtail_host/defaults/main.yml
+++ b/roles/promtail_host/defaults/main.yml
@@ -1,0 +1,29 @@
+---
+promtail_version: latest
+promtail_loki_url: https://draco-loki.linkorb.com/loki/api/v1/push
+promtail_loki_basic_auth: {}
+promtail_constellation_label: ''
+promtail_extra_labels: {}
+promtail_scrape_jobs:
+  - name: journal
+    journal:
+      path: /var/log/journal
+      max_age: 12h
+      labels:
+        job: systemd-journal
+      relabel_configs:
+        - source_labels: [__journal__systemd_unit]
+          target_label: unit
+  - name: syslog
+    static_configs:
+      - labels:
+          __path__: /var/log/syslog
+          job: syslog
+  - name: auditd
+    static_configs:
+      - labels:
+          __path__: /var/log/audit/audit.log
+          job: auditd
+promtail_http_listen_port: 9080
+promtail_grpc_listen_port: 0
+promtail_positions_file: /var/lib/promtail/positions.yaml

--- a/roles/promtail_host/defaults/main.yml
+++ b/roles/promtail_host/defaults/main.yml
@@ -1,29 +1,5 @@
 ---
-promtail_version: latest
 promtail_loki_url: https://draco-loki.linkorb.com/loki/api/v1/push
 promtail_loki_basic_auth: {}
 promtail_constellation_label: ''
 promtail_extra_labels: {}
-promtail_scrape_jobs:
-  - name: journal
-    journal:
-      path: /var/log/journal
-      max_age: 12h
-      labels:
-        job: systemd-journal
-      relabel_configs:
-        - source_labels: [__journal__systemd_unit]
-          target_label: unit
-  - name: syslog
-    static_configs:
-      - labels:
-          __path__: /var/log/syslog
-          job: syslog
-  - name: auditd
-    static_configs:
-      - labels:
-          __path__: /var/log/audit/audit.log
-          job: auditd
-promtail_http_listen_port: 9080
-promtail_grpc_listen_port: 0
-promtail_positions_file: /var/lib/promtail/positions.yaml

--- a/roles/promtail_host/handlers/main.yml
+++ b/roles/promtail_host/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Restart promtail
+  service:
+    name: promtail
+    state: restarted

--- a/roles/promtail_host/meta/main.yml
+++ b/roles/promtail_host/meta/main.yml
@@ -1,0 +1,2 @@
+---
+dependencies: []

--- a/roles/promtail_host/tasks/main.yml
+++ b/roles/promtail_host/tasks/main.yml
@@ -1,0 +1,58 @@
+---
+- name: Add Grafana apt key
+  apt_key:
+    url: https://apt.grafana.com/gpg.key
+    state: present
+  when: ansible_os_family == 'Debian'
+
+- name: Add Grafana apt repository
+  apt_repository:
+    repo: "deb https://apt.grafana.com stable main"
+    filename: grafana
+    state: present
+  when: ansible_os_family == 'Debian'
+
+- name: Install promtail
+  apt:
+    name: promtail
+    state: present
+    update_cache: yes
+  when: ansible_os_family == 'Debian'
+
+- name: Configure promtail user permissions
+  user:
+    name: promtail
+    groups:
+      - systemd-journal
+      - audit
+      - adm
+    append: yes
+
+- name: Ensure promtail state directory exists
+  file:
+    path: /var/lib/promtail
+    state: directory
+    owner: promtail
+    group: root
+    mode: '0750'
+
+- name: Ensure Loki push credentials are provided when basic auth is set
+  assert:
+    that:
+      - promtail_loki_basic_auth.name is defined
+      - promtail_loki_basic_auth.password is defined
+    fail_msg: "Set promtail_loki_basic_auth.name/password (see docs/logging.md)."
+  when: promtail_loki_basic_auth | length > 0
+
+- name: Render promtail configuration
+  template:
+    src: promtail-config.yml.j2
+    dest: /etc/promtail/config.yml
+    mode: '0644'
+  notify: Restart promtail
+
+- name: Ensure promtail service is enabled and running
+  service:
+    name: promtail
+    state: started
+    enabled: yes

--- a/roles/promtail_host/tasks/main.yml
+++ b/roles/promtail_host/tasks/main.yml
@@ -44,6 +44,12 @@
     fail_msg: "Set promtail_loki_basic_auth.name/password (see docs/logging.md)."
   when: promtail_loki_basic_auth | length > 0
 
+- name: Ensure Loki URL is provided
+  assert:
+    that:
+      - promtail_loki_url | length > 0
+    fail_msg: "Set promtail_loki_url (Loki push endpoint) via inventory or extra vars."
+
 - name: Render promtail configuration
   template:
     src: promtail-config.yml.j2

--- a/roles/promtail_host/templates/promtail-config.yml.j2
+++ b/roles/promtail_host/templates/promtail-config.yml.j2
@@ -1,0 +1,50 @@
+server:
+  http_listen_port: {{ promtail_http_listen_port }}
+  grpc_listen_port: {{ promtail_grpc_listen_port }}
+
+positions:
+  filename: {{ promtail_positions_file }}
+
+clients:
+  - url: '{{ promtail_loki_url }}'
+{% if promtail_loki_basic_auth.name is defined and promtail_loki_basic_auth.password is defined %}
+    basic_auth:
+      username: '{{ promtail_loki_basic_auth.name }}'
+      password: '{{ promtail_loki_basic_auth.password }}'
+{% endif %}
+    external_labels:
+      host: '{{ ansible_facts.hostname | default(ansible_hostname) }}'
+{% if promtail_constellation_label %}
+      constellation: '{{ promtail_constellation_label }}'
+{% endif %}
+{% for key, val in promtail_extra_labels.items() %}
+      {{ key }}: '{{ val }}'
+{% endfor %}
+
+scrape_configs:
+{% for job in promtail_scrape_jobs %}
+  - job_name: {{ job.name }}
+{% if job.journal is defined %}
+    journal:
+{% for key, val in job.journal.items() %}
+      {{ key }}: {{ val }}
+{% endfor %}
+{% endif %}
+{% if job.static_configs is defined %}
+    static_configs:
+{% for sc in job.static_configs %}
+      - labels:
+{% for key, val in sc.labels.items() %}
+          {{ key }}: {{ val }}
+{% endfor %}
+{% endfor %}
+{% endif %}
+{% if job.relabel_configs is defined %}
+    relabel_configs:
+{% for rc in job.relabel_configs %}
+      -{% for key, val in rc.items() %}
+        {{ key }}: {{ val }}
+{% endfor %}
+{% endfor %}
+{% endif %}
+{% endfor %}

--- a/roles/promtail_host/templates/promtail-config.yml.j2
+++ b/roles/promtail_host/templates/promtail-config.yml.j2
@@ -1,9 +1,9 @@
 server:
-  http_listen_port: {{ promtail_http_listen_port }}
-  grpc_listen_port: {{ promtail_grpc_listen_port }}
+  http_listen_port: 9080
+  grpc_listen_port: 0
 
 positions:
-  filename: {{ promtail_positions_file }}
+  filename: /var/lib/promtail/positions.yaml
 
 clients:
   - url: '{{ promtail_loki_url }}'
@@ -22,29 +22,25 @@ clients:
 {% endfor %}
 
 scrape_configs:
-{% for job in promtail_scrape_jobs %}
-  - job_name: {{ job.name }}
-{% if job.journal is defined %}
+  - job_name: journal
     journal:
-{% for key, val in job.journal.items() %}
-      {{ key }}: {{ val }}
-{% endfor %}
-{% endif %}
-{% if job.static_configs is defined %}
-    static_configs:
-{% for sc in job.static_configs %}
-      - labels:
-{% for key, val in sc.labels.items() %}
-          {{ key }}: {{ val }}
-{% endfor %}
-{% endfor %}
-{% endif %}
-{% if job.relabel_configs is defined %}
+      json: false
+      labels:
+        job: systemd-journal
+      max_age: 12h
+      path: /var/log/journal
     relabel_configs:
-{% for rc in job.relabel_configs %}
-      -{% for key, val in rc.items() %}
-        {{ key }}: {{ val }}
-{% endfor %}
-{% endfor %}
-{% endif %}
-{% endfor %}
+      - source_labels: [__journal__systemd_unit]
+        target_label: unit
+
+  - job_name: syslog
+    static_configs:
+      - labels:
+          __path__: /var/log/syslog
+          job: syslog
+
+  - job_name: auditd
+    static_configs:
+      - labels:
+          __path__: /var/log/audit/audit.log
+          job: auditd


### PR DESCRIPTION
## Proposed changes

- Added reusable logging/audit playbooks: playbooks/logging/audit_session.yml and playbooks/logging/promtail.yml.
- New role linkorb.polaris.audit_session: installs tlog/auditd, sets log_group, deploys tlog config, assigns shells/groups to admins, ensures auditd running.
- New role linkorb.polaris.promtail_host: installs promtail, adds required groups/dirs, renders simplified promtail config (journal/syslog/auditd scrapes), supports Loki basic auth/labels, ensures service running.
- Role docs/defaults/templates/handlers included for both roles.
