### PR TITLE
Fix: broken int conditionals

### DIFF
--- a/playbooks/lb/traefik.yaml
+++ b/playbooks/lb/traefik.yaml
@@ -13,7 +13,7 @@
         - /etc/traefik/certificates
         - /var/log/traefik
 
-    - when: polaris_traefik_tls_files | default([]) | length
+    - when: (polaris_traefik_tls_files | default([]) | length) > 0
       block:
         - name: Copy TLS cert files
           ansible.builtin.copy:

--- a/roles/stackmanager/tasks/main.yml
+++ b/roles/stackmanager/tasks/main.yml
@@ -34,7 +34,7 @@
   ansible.builtin.debug:
     var: manifest
     verbosity: 1
-  when: stacks_needing_tenant_info | length
+  when: (stacks_needing_tenant_info | length) > 0
 
 - name: 'Enrich selected stacks with tenant info'
   set_fact:
@@ -60,7 +60,7 @@
 - name: 'Debug: stacks_to_deploy (selected and enriched)'
   ansible.builtin.debug:
     var: stacks_to_deploy
-  when: stacks_to_deploy | length
+  when: (stacks_to_deploy | length) > 0
 
 - name: 'Deploy stacks'
   include_tasks: deploy-stack.yml


### PR DESCRIPTION
Even if the problem was obvious I don't quite see why it always happened on my Ansible and not on yours @boite ! I was forced to run with `allow_broken_conditionals = true`.

Maybe version mismatch? Mine is `core 2.20.1`.