### PR TITLE
Add NFS server layer

### DIFF
--- a/docs/nfs_layer.md
+++ b/docs/nfs_layer.md
@@ -1,0 +1,49 @@
+# NFS Layer
+
+The NFS layer is implemented as `linkorb.polaris.nfs.server` and is included from
+the main `layers.yml` playbook. It is intentionally a layer playbook rather than a
+role, because it represents a complete host layer that is applied once to hosts in
+`polaris_nfs_hosts`.
+
+Key design decisions:
+
+- The layer configures plain Linux NFS exports with `nfs-kernel-server`; it does
+  not provision distributed storage.
+- The inventory must define the dedicated data disk explicitly with
+  `polaris_nfs_data_disk`. The layer does not guess which block device is safe to
+  format.
+- The data disk is formatted as ext4 and mounted at `polaris_nfs_data_mount_point`.
+- Exports are written to `/etc/exports.d/polaris-nfs.exports` from
+  `polaris_nfs_exports`; the inventory owns the client networks and export
+  options.
+- Backups are optional. When `polaris_nfs_backup_enabled` is true, the inventory
+  must provide the restic repository URL, source path, schedule, region, and
+  credentials.
+
+Inventory example:
+
+```yaml
+polaris_nfs_hosts:
+  hosts:
+    nfs1:
+      polaris_nfs_data_disk: /dev/sdb
+      polaris_nfs_data_mount_point: /data
+      polaris_nfs_export_paths:
+        - /data/nfs-export
+        - /data/nfs-export/config
+      polaris_nfs_exports:
+        - path: /data/nfs-export
+          clients: 192.0.2.0/24
+          options: rw,sync,crossmnt,no_subtree_check,no_root_squash,fsid=0
+        - path: /data/nfs-export/config
+          clients: 192.0.2.0/24
+          options: rw,sync,no_subtree_check,no_root_squash
+      polaris_nfs_backup_enabled: true
+      polaris_nfs_backup_repository: s3:https://s3.example.net/example-bucket/restic
+      polaris_nfs_backup_source: /data/nfs-export
+      polaris_nfs_backup_aws_default_region: example-region
+      polaris_nfs_backup_calendar: "*-*-* 00:17:00"
+      polaris_nfs_backup_restic_password: "{{ vault_nfs_backup_restic_password }}"
+      polaris_nfs_backup_aws_access_key_id: "{{ vault_nfs_backup_aws_access_key_id }}"
+      polaris_nfs_backup_aws_secret_access_key: "{{ vault_nfs_backup_aws_secret_access_key }}"
+```

--- a/playbooks/layers.yml
+++ b/playbooks/layers.yml
@@ -34,6 +34,10 @@
 - name: Hosts are running Traefik ingress
   ansible.builtin.import_playbook: linkorb.polaris.lb.traefik
 
+# NFS layer
+- name: Hosts are running NFS exports
+  ansible.builtin.import_playbook: linkorb.polaris.nfs.server
+
 
 # Overlay layer
 - name: Hosts are Headscale nodes

--- a/playbooks/nfs/files/polaris-nfs-backup
+++ b/playbooks/nfs/files/polaris-nfs-backup
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+source /etc/polaris-nfs-backup.env
+
+backup_tag="$(date +%F)"
+
+export AWS_ACCESS_KEY_ID
+export AWS_SECRET_ACCESS_KEY
+export RESTIC_PASSWORD
+export AWS_DEFAULT_REGION
+export RESTIC_REPOSITORY
+
+log() {
+  printf '[%s] %s\n' "$(date --iso-8601=seconds)" "$*"
+}
+
+if ! restic snapshots >/dev/null 2>&1; then
+  log "initializing restic repository ${RESTIC_REPOSITORY}"
+  restic init
+fi
+
+log "starting backup of ${RESTIC_BACKUP_SOURCE}"
+restic backup "${RESTIC_BACKUP_SOURCE}" --host "$(hostname)" --tag "${backup_tag}"
+
+log "pruning old snapshots"
+restic forget --prune --keep-daily 7 --keep-weekly 4 --keep-monthly 12
+
+log "backup completed successfully"

--- a/playbooks/nfs/files/polaris-nfs-backup.service
+++ b/playbooks/nfs/files/polaris-nfs-backup.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Back up NFS data to S3-compatible object storage using restic
+Wants=network-online.target
+After=network-online.target
+ConditionPathExists=/etc/polaris-nfs-backup.env
+
+[Service]
+Type=oneshot
+User=root
+Group=root
+ExecStart=/usr/local/sbin/polaris-nfs-backup
+SyslogIdentifier=polaris-nfs-backup

--- a/playbooks/nfs/server.yml
+++ b/playbooks/nfs/server.yml
@@ -1,0 +1,187 @@
+- name: NFS - server
+  hosts: polaris_nfs_hosts
+  become: true
+  tags:
+    - polaris.nfs
+    - polaris.nfs.server
+
+  handlers:
+    - name: Reload NFS exports
+      ansible.builtin.command:
+        argv:
+          - exportfs
+          - -ra
+      changed_when: true
+
+    - name: Reload systemd
+      ansible.builtin.systemd_service:
+        daemon_reload: true
+
+    - name: Restart Polaris NFS backup timer
+      ansible.builtin.systemd_service:
+        name: polaris-nfs-backup.timer
+        enabled: true
+        state: restarted
+
+  tasks:
+    - name: Ensure NFS data variables are defined
+      ansible.builtin.assert:
+        that:
+          - polaris_nfs_data_disk is defined
+          - polaris_nfs_data_mount_point is defined
+          - polaris_nfs_export_paths is defined
+          - polaris_nfs_export_paths | length > 0
+          - polaris_nfs_exports is defined
+          - polaris_nfs_exports | length > 0
+        fail_msg: >-
+          Define polaris_nfs_data_disk, polaris_nfs_data_mount_point,
+          polaris_nfs_export_paths, and polaris_nfs_exports for each host in
+          polaris_nfs_hosts.
+
+    - name: Install NFS server packages
+      ansible.builtin.apt:
+        pkg: nfs-kernel-server
+        state: present
+        update_cache: true
+
+    - name: Create the NFS filesystem
+      community.general.filesystem:
+        dev: "{{ polaris_nfs_data_disk }}"
+        fstype: ext4
+
+    - name: Ensure the NFS mount point exists
+      ansible.builtin.file:
+        path: "{{ polaris_nfs_data_mount_point }}"
+        state: directory
+        owner: root
+        group: root
+        mode: "0755"
+
+    - name: Read the NFS filesystem UUID
+      ansible.builtin.command:
+        argv:
+          - blkid
+          - -s
+          - UUID
+          - -o
+          - value
+          - "{{ polaris_nfs_data_disk }}"
+      register: polaris_nfs_data_uuid
+      changed_when: false
+
+    - name: Mount the NFS filesystem
+      ansible.posix.mount:
+        path: "{{ polaris_nfs_data_mount_point }}"
+        src: "UUID={{ polaris_nfs_data_uuid.stdout }}"
+        fstype: ext4
+        opts: defaults
+        state: mounted
+
+    - name: Ensure exported directories exist
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: directory
+        owner: root
+        group: root
+        mode: "0775"
+      loop: "{{ polaris_nfs_export_paths }}"
+
+    - name: Ensure the NFS exports.d directory exists
+      ansible.builtin.file:
+        path: /etc/exports.d
+        state: directory
+        owner: root
+        group: root
+        mode: "0755"
+
+    - name: Install the NFS export definition
+      ansible.builtin.template:
+        src: polaris-nfs.exports.j2
+        dest: /etc/exports.d/polaris-nfs.exports
+        owner: root
+        group: root
+        mode: "0644"
+      notify: Reload NFS exports
+
+    - name: Ensure the NFS server is enabled and started
+      ansible.builtin.systemd_service:
+        name: nfs-kernel-server
+        enabled: true
+        state: started
+
+    - name: Ensure backup credentials are defined
+      ansible.builtin.assert:
+        that:
+          - polaris_nfs_backup_source is defined
+          - polaris_nfs_backup_aws_default_region is defined
+          - polaris_nfs_backup_calendar is defined
+          - polaris_nfs_backup_restic_password is defined
+          - polaris_nfs_backup_aws_access_key_id is defined
+          - polaris_nfs_backup_aws_secret_access_key is defined
+          - polaris_nfs_backup_repository is defined
+        fail_msg: >-
+          Define polaris_nfs_backup_source, polaris_nfs_backup_aws_default_region,
+          polaris_nfs_backup_calendar, polaris_nfs_backup_restic_password,
+          polaris_nfs_backup_aws_access_key_id,
+          polaris_nfs_backup_aws_secret_access_key, and
+          polaris_nfs_backup_repository when polaris_nfs_backup_enabled is true.
+      when: polaris_nfs_backup_enabled | default(false)
+
+    - name: Install restic
+      ansible.builtin.apt:
+        pkg: restic
+        state: present
+        update_cache: true
+      when: polaris_nfs_backup_enabled | default(false)
+
+    - name: Install the Polaris NFS backup environment file
+      ansible.builtin.template:
+        src: polaris-nfs-backup.env.j2
+        dest: /etc/polaris-nfs-backup.env
+        owner: root
+        group: root
+        mode: "0600"
+      notify: Restart Polaris NFS backup timer
+      when: polaris_nfs_backup_enabled | default(false)
+
+    - name: Install the Polaris NFS backup script
+      ansible.builtin.copy:
+        src: polaris-nfs-backup
+        dest: /usr/local/sbin/polaris-nfs-backup
+        owner: root
+        group: root
+        mode: "0750"
+      when: polaris_nfs_backup_enabled | default(false)
+
+    - name: Install the Polaris NFS backup systemd service
+      ansible.builtin.copy:
+        src: polaris-nfs-backup.service
+        dest: /etc/systemd/system/polaris-nfs-backup.service
+        owner: root
+        group: root
+        mode: "0644"
+      notify: Reload systemd
+      when: polaris_nfs_backup_enabled | default(false)
+
+    - name: Install the Polaris NFS backup systemd timer
+      ansible.builtin.template:
+        src: polaris-nfs-backup.timer.j2
+        dest: /etc/systemd/system/polaris-nfs-backup.timer
+        owner: root
+        group: root
+        mode: "0644"
+      notify:
+        - Reload systemd
+        - Restart Polaris NFS backup timer
+      when: polaris_nfs_backup_enabled | default(false)
+
+    - name: Flush backup systemd handlers before enabling the timer
+      ansible.builtin.meta: flush_handlers
+      when: polaris_nfs_backup_enabled | default(false)
+
+    - name: Enable and start the Polaris NFS backup timer
+      ansible.builtin.systemd_service:
+        name: polaris-nfs-backup.timer
+        enabled: true
+        state: started
+      when: polaris_nfs_backup_enabled | default(false)

--- a/playbooks/nfs/templates/polaris-nfs-backup.env.j2
+++ b/playbooks/nfs/templates/polaris-nfs-backup.env.j2
@@ -1,0 +1,6 @@
+AWS_DEFAULT_REGION={{ polaris_nfs_backup_aws_default_region }}
+RESTIC_REPOSITORY={{ polaris_nfs_backup_repository }}
+RESTIC_BACKUP_SOURCE={{ polaris_nfs_backup_source }}
+AWS_ACCESS_KEY_ID={{ polaris_nfs_backup_aws_access_key_id }}
+AWS_SECRET_ACCESS_KEY={{ polaris_nfs_backup_aws_secret_access_key }}
+RESTIC_PASSWORD={{ polaris_nfs_backup_restic_password }}

--- a/playbooks/nfs/templates/polaris-nfs-backup.timer.j2
+++ b/playbooks/nfs/templates/polaris-nfs-backup.timer.j2
@@ -1,0 +1,12 @@
+[Unit]
+Description=Nightly Polaris NFS restic backup
+
+[Timer]
+OnCalendar={{ polaris_nfs_backup_calendar }}
+AccuracySec=1m
+Persistent=true
+RandomizedDelaySec=0
+Unit=polaris-nfs-backup.service
+
+[Install]
+WantedBy=timers.target

--- a/playbooks/nfs/templates/polaris-nfs.exports.j2
+++ b/playbooks/nfs/templates/polaris-nfs.exports.j2
@@ -1,0 +1,3 @@
+{% for export in polaris_nfs_exports %}
+{{ export.path }} {{ export.clients }}({{ export.options }})
+{% endfor %}

--- a/variables.schema.yaml
+++ b/variables.schema.yaml
@@ -119,6 +119,68 @@ properties:
           description: A comma-separated list of options.
           examples: ['_netdev', 'defaults', 'noatime,nofail']
 
+  polaris_nfs_data_disk:
+    type: string
+    description: Dedicated block device to format and mount for NFS data.
+
+  polaris_nfs_data_mount_point:
+    type: string
+    description: Mount point for the dedicated NFS data filesystem.
+
+  polaris_nfs_export_paths:
+    type: array
+    description: Directories that should exist below the NFS data mount.
+    items:
+      type: string
+
+  polaris_nfs_exports:
+    type: array
+    description: NFS exports to write into exports.d.
+    items:
+      type: object
+      additionalProperties: false
+      required: ['path', 'clients', 'options']
+      properties:
+        path:
+          type: string
+        clients:
+          type: string
+        options:
+          type: string
+
+  polaris_nfs_backup_repository:
+    type: string
+    description: Restic repository URL for NFS backups.
+
+  polaris_nfs_backup_enabled:
+    type: boolean
+    default: false
+    description: Whether to configure the restic backup timer for NFS data.
+
+  polaris_nfs_backup_source:
+    type: string
+    description: Directory to back up with restic.
+
+  polaris_nfs_backup_aws_default_region:
+    type: string
+    description: AWS-compatible region name used by the restic S3 backend.
+
+  polaris_nfs_backup_calendar:
+    type: string
+    description: systemd calendar expression for the NFS backup timer.
+
+  polaris_nfs_backup_restic_password:
+    type: string
+    description: Restic repository password for NFS backups.
+
+  polaris_nfs_backup_aws_access_key_id:
+    type: string
+    description: S3-compatible access key ID for NFS backups.
+
+  polaris_nfs_backup_aws_secret_access_key:
+    type: string
+    description: S3-compatible secret access key for NFS backups.
+
   polaris_tailscale_authkey:
     type: string
     description: A Tailscale Node Authorization auth key.


### PR DESCRIPTION
Adds a Polaris NFS server layer playbook.

- Implements `linkorb.polaris.nfs.server` and includes it from `layers.yml`.
- Keeps the implementation as a layer playbook instead of a role, matching the collection pattern for complete host layers.
- Configures plain `nfs-kernel-server`, an ext4 data disk, exports.d entries, and restic backups.
- Documents the key design decisions in `docs/nfs_layer.md`.

Context: https://github.com/linkorb/polaris-inventory/pull/51#issuecomment-4335491029

The swarm join-token fix and broad check-mode skips were split out for separate review:
- https://github.com/linkorb/ansible-collection-polaris/pull/18
- https://github.com/linkorb/ansible-collection-polaris/pull/19