### PR TITLE
Skip runtime-only tasks in check mode

### DIFF
--- a/playbooks/baseline/juicefs_client.yml
+++ b/playbooks/baseline/juicefs_client.yml
@@ -31,9 +31,11 @@
         name: juicefs
         state: present
         update_cache: true
+      when: not ansible_check_mode
 
     - name: Point mount(8) to the juicefs mount program
       ansible.builtin.file:
         src: /usr/bin/juicefs
         dest: /sbin/mount.juicefs
         state: link
+      when: not ansible_check_mode

--- a/playbooks/container/docker_engine.yml
+++ b/playbooks/container/docker_engine.yml
@@ -34,18 +34,20 @@
     - polaris.container.docker_engine
   tasks:
     - name: Adding docker users (for use without sudo)
-      user:
+      ansible.builtin.user:
         name: "{{ item }}"
         append: true
         groups: docker
       become: true
       with_items: '{{ polaris_docker_users }}'
+      when: not ansible_check_mode
     - name: Install and enable juicedata/juicefs volume plugin
       community.docker.docker_plugin:
         plugin_name: "juicedata/juicefs:1.1.1"
         state: enable
         alias: juicefs
       become: true
+      when: not ansible_check_mode
 
 - name: Docker registry login
   hosts: '{{ target_group | default("polaris_hosts") }}'
@@ -60,3 +62,4 @@
         username: "{{ polaris_docker_registry_username }}"
         password: "{{ polaris_docker_registry_pat }}"
       become: true
+      when: not ansible_check_mode

--- a/playbooks/container/docker_swarm.yaml
+++ b/playbooks/container/docker_swarm.yaml
@@ -15,6 +15,7 @@
       default_addr_pool:
       - "{{ polaris_docker_swarm_default_addr_pool | default('10.135.0.0/16') }}"
     register: swarm_initialisation_info
+    when: not ansible_check_mode
   - name: Peek at swarm_initialisation_info
     debug:
       var: swarm_initialisation_info
@@ -51,6 +52,7 @@
       - "{{ polaris_docker_swarm_default_addr_pool | default('10.135.0.0/16') }}"
       remote_addrs:
       - "{{ polaris_docker_swarm_advertise_address | default(target_swarm_facts.default_ipv4.address) | default(target_swarm_facts.all_ipv4_addresses[0]) }}"
+    when: not ansible_check_mode
 
 
 - name: Swarm Workers are joined to their Swarms
@@ -79,6 +81,7 @@
       - "{{ polaris_docker_swarm_default_addr_pool | default('10.135.0.0/16') }}"
       remote_addrs:
       - "{{ polaris_docker_swarm_advertise_address | default(target_swarm_facts.default_ipv4.address) | default(target_swarm_facts.all_ipv4_addresses[0]) }}"
+    when: not ansible_check_mode
 
 
 - name: Swarm managers are labelled
@@ -96,6 +99,7 @@
         labels: "{{ node_labels | default({}) }}"
         labels_state: replace
         labels_to_remove: "{{ polaris_docker_swarm_node_labels_to_remove | default([]) }}"
+      when: not ansible_check_mode
 
 - name: Swarm workers are labelled
   hosts:
@@ -112,3 +116,4 @@
         labels: "{{ hostvars[inventory_hostname]['node_labels'] | default({}) }}"
         labels_state: replace
         labels_to_remove: "{{ polaris_docker_swarm_node_labels_to_remove | default([]) }}"
+      when: not ansible_check_mode


### PR DESCRIPTION
This extracts the broad check-mode safety changes from the Vela NFS work so they can be reviewed independently.

- Skip JuiceFS package/link tasks in check mode.
- Skip Docker user/plugin/login mutations in check mode.
- Skip Docker Swarm mutations and label updates in check mode.

The goal is to let broad dry-runs get past runtime-only tasks without changing the target host.